### PR TITLE
Add DTK-2100 to supported models.

### DIFF
--- a/Readme.en-simple.md
+++ b/Readme.en-simple.md
@@ -42,7 +42,7 @@ My fixed **Graphire 4** driver (v5.3.0-3) supports these tablets:
 My fixed **Intuos 3** and **Cintiq** driver (v6.3.15-3) supports these tablets:
 
 - PTZ-430, PTZ-630, PTZ-630SE, PTZ-631W, PTZ-930, PTZ-1230, PTZ-1231W - Intuos 3
-- DTZ-2100 - Cintiq 21UX 1st Gen.
+- DTZ-2100, DTK-2100 - Cintiq 21UX 1st Gen.
 - DTZ-2000 - Cintiq 20WSX
 
 [🇳🇿 English instructions](Readme.md)  

--- a/Readme.es.md
+++ b/Readme.es.md
@@ -42,7 +42,7 @@ Mi controlador corregido Graphire 4 (v5.3.0-3) es compatible con estas tabletas:
 Mi controlador corregido de Intuos 3 y Cintiq (v6.3.15-3) es compatible con estas tabletas:
 
 - PTZ-430, PTZ-630, PTZ-630SE, PTZ-631W, PTZ-930, PTZ-1230, PTZ-1231W - Intuos 3
-- DTZ-2100 - Cintiq 21UX 1.ª generación
+- DTZ-2100, DTK-2100 - Cintiq 21UX 1.ª generación
 - DTZ-2000 - Cintiq 20WSX
 
 [🇳🇿 English instructions](Readme.md)   

--- a/Readme.fr-FR.md
+++ b/Readme.fr-FR.md
@@ -42,7 +42,7 @@ Mon pilote corrigé **Graphire 4** (v5.3.0-3) prend en charge ces tablettes:
 Mon pilote corrigé **Intuos 3** et **Cintiq** (v6.3.15-3) prend en charge ces tablettes:
 
 - PTZ-430, PTZ-630, PTZ-630SE, PTZ-631W, PTZ-930, PTZ-1230, PTZ-1231W - Intuos 3
-- DTZ-2100 - Cintiq 21UX 1st Gen.
+- DTZ-2100, DTK-2100 - Cintiq 21UX 1st Gen.
 - DTZ-2000 - Cintiq 20WSX
 
 [🇳🇿 English instructions](Readme.md)  

--- a/Readme.ja-JP.md
+++ b/Readme.ja-JP.md
@@ -41,7 +41,7 @@ Graphire 4修正ドライバー (v5.3.0-3) 対応デバイス：
 Intuos/Cintiq修正ドライバー (v6.3.15-3) 対応デバイス：
 
 - PTZ-430, PTZ-630, PTZ-630SE, PTZ-631W, PTZ-930, PTZ-1230, PTZ-1231W - Intuos 3
-- DTZ-2100 - Cintiq 21UX 1st Gen.
+- DTZ-2100, DTK-2100 - Cintiq 21UX 1st Gen.
 - DTZ-2000 - Cintiq 20WSX
 
 [🇳🇿 English instructions](Readme.md)   

--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ My fixed **Graphire 4** driver (v5.3.0-3) supports these tablets:
 And my fixed **Intuos 3** and **Cintiq** driver (v6.3.15-3) supports these tablets:
 
 - PTZ-430, PTZ-630, PTZ-630SE, PTZ-631W, PTZ-930, PTZ-1230, PTZ-1231W - Intuos 3
-- DTZ-2100 - Cintiq 21UX 1st Gen.
+- DTZ-2100, DTK-2100 - Cintiq 21UX 1st Gen.
 - DTZ-2000 - Cintiq 20WSX
 
 For **Intuos 4** my fix is not needed. You can use [Wacom's official driver v6.3.41-2](https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_6.3.41-2.dmg) instead.

--- a/Readme.pl.md
+++ b/Readme.pl.md
@@ -52,7 +52,7 @@ Zaktualizowane sterowniki tabletów Graphire 4 (v5.3.0-3) wspierają następują
 Zaktualizowane sterowniki tabletów Inutos 3 oraz Cintiq (v6.3.15-3) wspierają następujące tablety:
 
 - PTZ-430, PTZ-630, PTZ-630SE, PTZ-631W, PTZ-930, PTZ-1230, PTZ-1231W - Intuos 3
-- DTZ-2100 - Cintiq 21UX 1st Gen.
+- DTZ-2100, DTK-2100 - Cintiq 21UX 1st Gen.
 - DTZ-2000 - Cintiq 20WSX
 
 [🇳🇿 English instructions](Readme.md)   

--- a/Readme.pt-BR.md
+++ b/Readme.pt-BR.md
@@ -41,7 +41,7 @@ O driver Graphire 4 fixo (v5.3.0-3) suporta estes tablets:
 O driver Intuos 3 e Cintiq fixo (v6.3.15-3) suporta estes tablets:
 
 - PTZ-430, PTZ-630, PTZ-630SE, PTZ-631W, PTZ-930, PTZ-1230, PTZ-1231W - Intuos 3
-- DTZ-2100 - Cintiq 21UX 1st Gen.
+- DTZ-2100, DTK-2100 - Cintiq 21UX 1st Gen.
 - DTZ-2000 - Cintiq 20WSX
 
 [🇳🇿 English instructions](Readme.md)   

--- a/Readme.ru-RU.md
+++ b/Readme.ru-RU.md
@@ -49,7 +49,7 @@ with your tablet driver. Please reboot your system. If the problem persists rein
 Поврежденный драйвер Intuos and Cintiq driver (v6.3.15-3) подходит для планшетов:
 
 - PTZ-430, PTZ-630, PTZ-630SE, PTZ-631W, PTZ-930, PTZ-1230, PTZ-1231W - Intuos 3
-- DTZ-2100 - Cintiq 21UX 1st Gen.
+- DTZ-2100, DTK-2100 - Cintiq 21UX 1st Gen.
 - DTZ-2000 - Cintiq 20WSX
 
 К счастью, я смог отследить ошибки и пропатчил драйверы таким образом чтобы они заработали корректно!


### PR DESCRIPTION
I have confirmed the patched driver (v6.3.15-3) works on macOS Sonoma Version 14.1.1 with an Intel processor.